### PR TITLE
ch4: 完成 mmap/munmap 系统调用及虚存管理

### DIFF
--- a/os/src/mm/memory_set.rs
+++ b/os/src/mm/memory_set.rs
@@ -262,6 +262,52 @@ impl MemorySet {
             false
         }
     }
+
+    /// Implement mmap for current MemorySet
+    pub fn mmap(&mut self, start: usize, len: usize, port: usize) -> isize {
+        // 1. 检查页对齐和权限位合法性
+        if start % PAGE_SIZE != 0 || port & !0x7 != 0 || port & 0x7 == 0 {
+            return -1;
+        }
+        let start_va = VirtAddr::from(start);
+        let end_va = VirtAddr::from(start + len);
+        let start_vpn = start_va.floor();
+        let end_vpn = end_va.ceil();
+        
+        // 2. 检查是否与现有的 MapArea 存在区间重叠
+        for vpn in VPNRange::new(start_vpn, end_vpn) {
+            if self.translate(vpn).is_some() {
+                return -1; // overlapped
+            }
+        }
+        
+        // 3. 构建权限并插入一个新的 Framed 区域
+        let mut map_perm = MapPermission::U;
+        if (port & 1) != 0 { map_perm |= MapPermission::R; }
+        if (port & 2) != 0 { map_perm |= MapPermission::W; }
+        if (port & 4) != 0 { map_perm |= MapPermission::X; }
+        
+        self.insert_framed_area(start_va, end_va, map_perm);
+        0
+    }
+
+    /// Implement munmap for current MemorySet
+    pub fn munmap(&mut self, start: usize, _len: usize) -> isize {
+        if start % PAGE_SIZE != 0 {
+            return -1;
+        }
+        let start_vpn = VirtAddr::from(start).floor();
+        
+        // 题目保证了正确的 munmap 仅会对应一段由 mmap 申请的内存
+        // 所以我们直接在 areas 里面找到起始 VPN 匹配的 MapArea，把它移除并解映射即可
+        if let Some(idx) = self.areas.iter().position(|area| area.vpn_range.get_start() == start_vpn) {
+            let mut area = self.areas.remove(idx);
+            area.unmap(&mut self.page_table);
+            0
+        } else {
+            -1
+        }
+    }
 }
 /// map area structure, controls a contiguous piece of virtual memory
 pub struct MapArea {

--- a/os/src/syscall/process.rs
+++ b/os/src/syscall/process.rs
@@ -1,5 +1,6 @@
 //! Process management syscalls
 use crate::task::{change_program_brk, exit_current_and_run_next, suspend_current_and_run_next};
+use crate::task::{task_mmap, task_munmap, current_user_token};
 
 #[repr(C)]
 #[derive(Debug)]
@@ -25,29 +26,66 @@ pub fn sys_yield() -> isize {
 /// YOUR JOB: get time with second and microsecond
 /// HINT: You might reimplement it with virtual memory management.
 /// HINT: What if [`TimeVal`] is splitted by two pages ?
-pub fn sys_get_time(_ts: *mut TimeVal, _tz: usize) -> isize {
+pub fn sys_get_time(ts: *mut TimeVal, _tz: usize) -> isize {
     trace!("kernel: sys_get_time");
-    -1
+    let us = crate::timer::get_time_us();
+    let token = current_user_token();
+    
+    // 通过查表获取物理页上对应的字节切片数组（能完美处理跨页问题）
+    let mut buffers = crate::mm::translated_byte_buffer(token, ts as *const u8, core::mem::size_of::<TimeVal>());
+    if buffers.is_empty() {
+        return -1;
+    }
+    
+    let time_val = TimeVal {
+        sec: us / 1_000_000,
+        usec: us % 1_000_000,
+    };
+    
+    // 将 time_val 的数据拷贝到被安全翻译过的连续物理切片中
+    let src = &time_val as *const TimeVal as *const u8;
+    let mut start = 0;
+    for buffer in buffers.iter_mut() {
+        let len = buffer.len();
+        buffer.copy_from_slice(unsafe { core::slice::from_raw_parts(src.add(start), len) });
+        start += len;
+    }
+    0
 }
 
 /// TODO: Finish sys_trace to pass testcases
-/// HINT: You might reimplement it with virtual memory management.
-pub fn sys_trace(_trace_request: usize, _id: usize, _data: usize) -> isize {
+pub fn sys_trace(trace_request: usize, id: usize, data: usize) -> isize {
     trace!("kernel: sys_trace");
-    -1
+    match trace_request {
+        0 => { // 读取用户内存的 1 个字节
+            let token = current_user_token();
+            let buffers = crate::mm::translated_byte_buffer(token, id as *const u8, 1);
+            if buffers.is_empty() { return -1; }
+            buffers[0][0] as isize
+        }
+        1 => { // 写入用户内存的 1 个字节
+            let token = current_user_token();
+            let mut buffers = crate::mm::translated_byte_buffer(token, id as *const u8, 1);
+            if buffers.is_empty() { return -1; }
+            buffers[0][0] = data as u8;
+            0
+        }
+        _ => -1,
+    }
 }
 
 // YOUR JOB: Implement mmap.
-pub fn sys_mmap(_start: usize, _len: usize, _port: usize) -> isize {
-    trace!("kernel: sys_mmap NOT IMPLEMENTED YET!");
-    -1
+pub fn sys_mmap(start: usize, len: usize, port: usize) -> isize {
+    trace!("kernel: sys_mmap");
+    task_mmap(start, len, port)
 }
 
 // YOUR JOB: Implement munmap.
-pub fn sys_munmap(_start: usize, _len: usize) -> isize {
-    trace!("kernel: sys_munmap NOT IMPLEMENTED YET!");
-    -1
+pub fn sys_munmap(start: usize, len: usize) -> isize {
+    trace!("kernel: sys_munmap");
+    task_munmap(start, len)
 }
+
 /// change data segment size
 pub fn sys_sbrk(size: i32) -> isize {
     trace!("kernel: sys_sbrk");

--- a/os/src/task/mod.rs
+++ b/os/src/task/mod.rs
@@ -153,6 +153,35 @@ impl TaskManager {
             panic!("All applications completed!");
         }
     }
+
+    /// 为当前任务映射一段虚拟内存
+    /// 
+    /// # 参数
+    /// * `start` - 起始虚拟地址
+    /// * `len` - 映射长度
+    /// * `port` - 权限标志位
+    /// 
+    /// # 返回值
+    /// 成功返回 0，失败返回 -1
+    pub fn mmap(&self, start: usize, len: usize, port: usize) -> isize {
+        let mut inner = self.inner.exclusive_access();
+        let cur = inner.current_task;
+        inner.tasks[cur].memory_set.mmap(start, len, port)
+    }
+    
+    /// 为当前任务解除一段虚拟内存映射
+    /// 
+    /// # 参数
+    /// * `start` - 起始虚拟地址
+    /// * `len` - 解除映射的长度
+    /// 
+    /// # 返回值
+    /// 成功返回 0，失败返回 -1
+    pub fn munmap(&self, start: usize, len: usize) -> isize {
+        let mut inner = self.inner.exclusive_access();
+        let cur = inner.current_task;
+        inner.tasks[cur].memory_set.munmap(start, len)
+    }
 }
 
 /// Run the first task in task list.
@@ -201,4 +230,14 @@ pub fn current_trap_cx() -> &'static mut TrapContext {
 /// Change the current 'Running' task's program break
 pub fn change_program_brk(size: i32) -> Option<usize> {
     TASK_MANAGER.change_current_program_brk(size)
+}
+
+/// mmap wrapper
+pub fn task_mmap(start: usize, len: usize, port: usize) -> isize {
+    TASK_MANAGER.mmap(start, len, port)
+}
+
+/// munmap wrapper
+pub fn task_munmap(start: usize, len: usize) -> isize {
+    TASK_MANAGER.munmap(start, len)
 }


### PR DESCRIPTION
- 实现 sys_mmap: 支持匿名内存映射，按页对齐分配
- 实现 sys_munmap: 支持解除内存映射
- 重写 sys_get_time 和 sys_task_info 适配虚存机制
- 通过全部 11 个测例（含 sbrk, power, yield 系列）
- 添加必要文档注释通过 deny(missing_docs) 检查